### PR TITLE
Add time record enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kot-sdk",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Node.js SDK for King of Time Web API ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/interfaces/kot-api/v1/index.ts
+++ b/src/interfaces/kot-api/v1/index.ts
@@ -55,10 +55,17 @@ export namespace API {
         longtitude?: number
       }
 
+      enum TimeRecordCode {
+        ClockIn,
+        ClockOut,
+        StartBreak,
+        EndBreak
+      }
+
       export interface RecordRequestWithCode {
         date: string
         time: string
-        code: number
+        code: TimeRecordCode
         divisionCode: string
       }
 


### PR DESCRIPTION
## WHY

BEcause it's easier to specify with enum instead of using the magic numbers.